### PR TITLE
remove kubectl provider

### DIFF
--- a/.github/workflows/tfdocs.yaml
+++ b/.github/workflows/tfdocs.yaml
@@ -1,0 +1,12 @@
+name: Generate Tfdocs
+on:
+  - pull_request
+
+jobs:
+ module_matrix:
+   strategy:
+      matrix:
+         module: ["../."]
+   uses: montblu/github-actions/.github/workflows/tfdocs.yaml@main
+   with:
+     target: ${{ matrix.module }}

--- a/main.tf
+++ b/main.tf
@@ -939,8 +939,3 @@ YAML
     kubernetes_service.main
   ]
 }
-
-moved {
-  from = kubectl_manifest.main
-  to   = kubernetes_manifest.main
-}

--- a/main.tf
+++ b/main.tf
@@ -917,10 +917,10 @@ resource "kubernetes_service" "main" {
 ################################################################################
 # ServiceMonitor (Prometheus-Operator)
 ################################################################################
-resource "kubectl_manifest" "main" {
+resource "kubernetes_manifest" "main" {
   count = var.deployment.create && var.deployment.create_svc && var.deployment.create_svc_monitor ? 1 : 0
 
-  yaml_body = <<YAML
+  manifest = yamldecode(<<YAML
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -933,8 +933,14 @@ spec:
   endpoints:
     - path: "${var.deployment.svc_monitor_path}"
 YAML
+  )
 
   depends_on = [
     kubernetes_service.main
   ]
+}
+
+moved {
+  from = kubectl_manifest.main
+  to   = kubernetes_manifest.main
 }

--- a/versions.tf
+++ b/versions.tf
@@ -10,9 +10,5 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = ">= 2.23.0"
     }
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14.0"
-    }
   }
 }


### PR DESCRIPTION
replace `kubectl_manifest` by `kubernetes_manifest` 

This will require a major bump of the module, due to possible incompatibilities with how this module is used.
Namely:
1. It requires access to the cluster API during the planning phase, as per its [official docs](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest#before-you-use-this-resource).
2. Any CRD (Custom Resource Definition) must already exist in the cluster during the planning phase


more info:
https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest
https://medium.com/@danieljimgarcia/dont-use-the-terraform-kubernetes-manifest-resource-6c7ff4fe629a