### PR TITLE
fix literal endpoints for ServiceMonitor

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -949,8 +949,8 @@ spec:
     matchLabels:
       app: ${local.resource_name}
   endpoints:
-    - path: var.deployment.svc_monitor_path
-      port: var.deployment.svc_monitor_port
+    - path: ${var.deployment.svc_monitor_path}
+      port: ${var.deployment.svc_monitor_port}
 YAML
   )
 


### PR DESCRIPTION
fix regression introduced by 5d2afc32ebd2a387d04931c4283e1e4996d0e9ec for release [v8.1.0](https://github.com/montblu/terraform-kubernetes-deployment/releases/tag/v8.1.0)

Fixing this bug which was producing changes like:
```
  ~ resource "kubernetes_manifest" "main" {
      ~ manifest = {
          ~ spec       = {
              ~ endpoints = [
                  ~ {
                      ~ path = "/metrics" -> "var.deployment.svc_monitor_path"
                      + port = "var.deployment.svc_monitor_port"
                    },
                ]
                # (1 unchanged attribute hidden)
            }
            # (3 unchanged attributes hidden)
        }
```